### PR TITLE
Remove proc macro dependencies

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 //! );
 //! ```
 //!
-//! ## Use key event "literals" thanks to procedural macros
+//! ## Use key event "literals"
 //!
 //! Those key events are parsed at compile time and have zero runtime cost.
 //!
@@ -68,15 +68,13 @@
 //! assert_eq!(format.to_string(key!(shift-a)), "A");
 //! assert_eq!(format.to_string(key!(ctrl-c)), "^c");
 //! ```
+#![allow(uncommon_codepoints)] // See key_code in macros.rs
 
 mod format;
+mod macros;
 mod parse;
 
-pub use {
-    crokey_proc_macros::*,
-    format::*,
-    parse::*,
-};
+pub use {format::*, macros::*, parse::*};
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,236 @@
+/// Check and expand at compile-time the provided expression
+/// into a valid [`KeyEvent`].
+///
+///
+/// For example:
+/// ```
+/// # use crokey::key;
+/// let key_event = key!(ctrl-c);
+/// ```
+/// is expanded into something like:
+///
+/// ```
+/// let key_event = crossterm::event::KeyEvent {
+///     modifiers: crossterm::event::KeyModifiers::CONTROL,
+///     code: crossterm::event::KeyCode::Char('\u{63}'),
+/// };
+/// ```
+///
+/// The input format is a sequence of hyphen-separated modifiers (`ctrl`, `alt` and `shift`)
+/// followed by the key code (which is interpreted identically to [`key_codeǃ`]).
+///
+/// [`KeyEvent`]: crossterm::event::KeyEvent
+#[macro_export]
+macro_rules! key {
+    ($($input:tt)*) => { $crate::__key_inner!(parse_modifier NONE NONE NONE $($input)*) };
+}
+
+// Unstable private API for use by `key!` only.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __key_inner {
+    (parse_modifier NONE $alt:tt $shift:tt ctrl $($rest:tt)*) => {
+        $crate::__key_inner!(expect_dash CONTROL $alt $shift $($rest)*)
+    };
+    (parse_modifier CONTROL $alt:tt $shift:tt ctrl $($rest:tt)*) => {
+        $crate::__private::core::compile_error!("ctrl specified twice")
+    };
+    (parse_modifier $ctrl:tt $alt:tt $shift:tt control $($rest:tt)*) => {
+        $crate::__private::core::compile_error!("use `ctrl`, not `control`")
+    };
+    (parse_modifier $ctrl:tt NONE $shift:tt alt $($rest:tt)*) => {
+        $crate::__key_inner!(expect_dash $ctrl ALT $shift $($rest)*)
+    };
+    (parse_modifier $ctrl:tt ALT $shift:tt alt $($rest:tt)*) => {
+        $crate::__private::core::compile_error!("alt specified twice")
+    };
+    (parse_modifier $ctrl:tt $alt:tt NONE shift $($rest:tt)*) => {
+        $crate::__key_inner!(expect_dash $ctrl $alt SHIFT $($rest)*)
+    };
+    (parse_modifier $ctrl:tt $alt:tt SHIFT shift $($rest:tt)*) => {
+        $crate::__private::core::compile_error!("shift specified twice")
+    };
+    (parse_modifier $ctrl:tt $alt:tt $shift:tt $($code:tt)*) => {
+        $crate::__private::crossterm::event::KeyEvent {
+            code: $crate::key_code!($($code)*),
+            modifiers: $crate::__private::crossterm::event::KeyModifiers::$ctrl
+                | $crate::__private::crossterm::event::KeyModifiers::$alt
+                | $crate::__private::crossterm::event::KeyModifiers::$shift,
+        }
+    };
+
+    (expect_dash $ctrl:tt $alt:tt $shift:tt - $($rest:tt)*) => {
+        $crate::__key_inner!(parse_modifier $ctrl $alt $shift $($rest)*)
+    };
+    // Split apart combined tokens like `-=` and `->` into their individual parts
+    (expect_dash $ctrl:tt $alt:tt $shift:tt -= $($rest:tt)*) => {
+        $crate::__key_inner!(parse_modifier $ctrl $alt $shift = $($rest)*)
+    };
+    (expect_dash $ctrl:tt $alt:tt $shift:tt -> $($rest:tt)*) => {
+        $crate::__key_inner!(parse_modifier $ctrl $alt $shift > $($rest)*)
+    };
+    (expect_dash $ctrl:tt $alt:tt $shift:tt $($rest:tt)*) => {
+        $crate::__private::core::compile_error!("expected hyphen after modifier")
+    };
+}
+
+/// Check and expand at compile-time the provided expression into a valid [`KeyCode`].
+///
+/// For example:
+///
+/// ```
+/// let code = crokey::key_code!(c);
+/// ```
+///
+/// is expanded into something like:
+///
+/// ```
+/// let code = crossterm::event::KeyCode::Char('c');
+/// ```
+///
+/// This macro accepts:
+/// - Special identifiers for special keys (e.g. `up`, `down`, `left` and `right` for arrow keys).
+/// - Single-letter identifiers for `char`-key codes (e.g. `a`).
+/// - Single digits for the number keys.
+/// - Punctuation characters that Rust supports (e.g. `:` and `+`).
+/// - Character literals for any other character (e.g. `']'` or `'('`).
+///
+/// [`KeyCode`]: crossterm::event::KeyCode
+// rustfmt wants to place each macro arm on its own line, which is terrible for readability.
+#[rustfmt::skip]
+#[macro_export]
+macro_rules! key_codeǃ {
+    (backspace) => { $crate::__private::KeyCode::Backspace };
+    (backtab) => { $crate::__private::KeyCode::BackTab };
+    (del) => { $crate::__private::KeyCode::Delete };
+    (delete) => { $crate::__private::KeyCode::Delete };
+    (down) => { $crate::__private::KeyCode::Down };
+    (end) => { $crate::__private::KeyCode::End };
+    (enter) => { $crate::__private::KeyCode::Enter };
+    (esc) => { $crate::__private::KeyCode::Esc };
+    (f1) => { $crate::__private::KeyCode::F(1) };
+    (f2) => { $crate::__private::KeyCode::F(2) };
+    (f3) => { $crate::__private::KeyCode::F(3) };
+    (f4) => { $crate::__private::KeyCode::F(4) };
+    (f5) => { $crate::__private::KeyCode::F(5) };
+    (f6) => { $crate::__private::KeyCode::F(6) };
+    (f7) => { $crate::__private::KeyCode::F(7) };
+    (f8) => { $crate::__private::KeyCode::F(8) };
+    (f9) => { $crate::__private::KeyCode::F(9) };
+    (f10) => { $crate::__private::KeyCode::F(10) };
+    (f11) => { $crate::__private::KeyCode::F(11) };
+    (f12) => { $crate::__private::KeyCode::F(12) };
+    (home) => { $crate::__private::KeyCode::Home };
+    (ins) => { $crate::__private::KeyCode::Insert };
+    (insert) => { $crate::__private::KeyCode::Insert };
+    (left) => { $crate::__private::KeyCode::Left };
+    (pagedown) => { $crate::__private::KeyCode::PageDown };
+    (pageup) => { $crate::__private::KeyCode::PageUp };
+    (right) => { $crate::__private::KeyCode::Right };
+    (space) => { $crate::__private::KeyCode::Char(' ') };
+    (tab) => { $crate::__private::KeyCode::Tab };
+    (up) => { $crate::__private::KeyCode::Up };
+    (0) => { $crate::__private::KeyCode::Char('0') };
+    (1) => { $crate::__private::KeyCode::Char('1') };
+    (2) => { $crate::__private::KeyCode::Char('2') };
+    (3) => { $crate::__private::KeyCode::Char('3') };
+    (4) => { $crate::__private::KeyCode::Char('4') };
+    (5) => { $crate::__private::KeyCode::Char('5') };
+    (6) => { $crate::__private::KeyCode::Char('6') };
+    (7) => { $crate::__private::KeyCode::Char('7') };
+    (8) => { $crate::__private::KeyCode::Char('8') };
+    (9) => { $crate::__private::KeyCode::Char('9') };
+    // some character literals map better to non-`Char` `KeyCode`s
+    ('\x08') => { $crate::__private::KeyCode::Backspace };
+    ('\x7F') => { $crate::__private::KeyCode::Delete };
+    ('\n') => { $crate::__private::KeyCode::Enter };
+    ('\x1B') => { $crate::__private::KeyCode::Esc };
+    ('\t') => { $crate::__private::KeyCode::Tab };
+    // `-` is normally treated as a literal, which is incorrect
+    (-) => { $crate::__private::KeyCode::Char('-') };
+    // should be a character literal
+    ($c:literal) => { $crate::__private::KeyCode::Char($c) };
+    // punctuation or an identifier
+    ($tt:tt) => {
+        $crate::__private::KeyCode::Char($crate::__private::crokey_proc_macros::to_char!($tt))
+    };
+    ($($tt:tt)*) => {
+        $crate::__private::core::compile_error!(concat!("unknown key code `", stringify!($($tt)*), "`"))
+    }
+}
+// A hack to work around https://github.com/rust-lang/rust/issues/74087. The problem is that
+// because the actual definition of key_code! uses `#[rustfmt::skip]` it can't be referred to by
+// absolute paths, so instead we have to refer to a re-export of it. Usually we would name the real
+// macro `__key_code` and the re-export `key_code`, but then either both or only `__key_code` would
+// show up in documentation. So instead we name the real macro `key_codeǃ`, adding a LATIN LETTER
+// RETROFLEX CLICK (not an exclamation mark as they aren't valid in identifiers) at the end so that
+// it doesn't look weird in documentation. Only the most observant users will notice that rustdoc
+// doesn't usually place exclamation marks at the end of macro names.
+#[doc(hidden)]
+pub use key_codeǃ as key_code;
+
+// Unstable private API for use by `key!` and `key_code!` only.
+#[doc(hidden)]
+pub mod __private {
+    pub use {core, crokey_proc_macros, crossterm, crossterm::event::KeyCode};
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        crate::{key, key_code},
+        crossterm::event::{KeyCode, KeyEvent, KeyModifiers},
+    };
+
+    #[test]
+    fn key_code() {
+        assert_eq!(key_code!(backspace), KeyCode::Backspace);
+        assert_eq!(key_code!(5), KeyCode::Char('5'));
+        assert_eq!(key_code!('\x08'), KeyCode::Backspace);
+        assert_eq!(key_code!('\n'), KeyCode::Enter);
+        assert_eq!(key_code!('x'), KeyCode::Char('x'));
+        assert_eq!(key_code!(']'), KeyCode::Char(']'));
+        assert_eq!(key_code!('ඞ'), KeyCode::Char('ඞ'));
+        assert_eq!(key_code!(:), KeyCode::Char(':'));
+        assert_eq!(key_code!(+), KeyCode::Char('+'));
+        assert_eq!(key_code!(f), KeyCode::Char('f'));
+        assert_eq!(key_code!(ඞ), KeyCode::Char('ඞ'));
+    }
+
+    #[test]
+    fn key() {
+        assert_eq!(
+            key!(-),
+            KeyEvent::new(KeyCode::Char('-'), KeyModifiers::NONE)
+        );
+        assert_eq!(
+            key!(+),
+            KeyEvent::new(KeyCode::Char('+'), KeyModifiers::NONE)
+        );
+        assert_eq!(
+            key!(ctrl-=),
+            KeyEvent::new(KeyCode::Char('='), KeyModifiers::CONTROL)
+        );
+        assert_eq!(
+            key!(ctrl->),
+            KeyEvent::new(KeyCode::Char('>'), KeyModifiers::CONTROL)
+        );
+        assert_eq!(
+            key!(ctrl--),
+            KeyEvent::new(KeyCode::Char('-'), KeyModifiers::CONTROL)
+        );
+        assert_eq!(
+            key!(shift-=),
+            KeyEvent::new(KeyCode::Char('='), KeyModifiers::SHIFT)
+        );
+        assert_eq!(
+            key!(alt-shift-=),
+            KeyEvent::new(KeyCode::Char('='), KeyModifiers::ALT | KeyModifiers::SHIFT)
+        );
+        assert_eq!(key!(shift - alt - 2), key!(alt - shift - 2));
+        assert_eq!(
+            key!( alt - shift - = ),
+            KeyEvent::new(KeyCode::Char('='), KeyModifiers::ALT | KeyModifiers::SHIFT)
+        );
+    }
+}

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -113,7 +113,7 @@ fn check_key_parsing() {
     }
     check_ok("left", key!(left));
     check_ok("RIGHT", key!(right));
-    check_ok("Home", key!(HOME));
+    check_ok("Home", key!(home));
     check_ok("f1", KeyEvent::from(F(1)));
     check_ok("F2", KeyEvent::from(F(2)));
     check_ok("Enter", KeyEvent::from(Enter));

--- a/src/proc_macros/Cargo.toml
+++ b/src/proc_macros/Cargo.toml
@@ -7,10 +7,6 @@ license = "MIT"
 edition = "2018"
 
 [dependencies]
-crossterm = "0.22.1"
-syn = { version = "1.0", features = ["full"] }
-proc-macro2 = "1.0"
-quote = "1.0"
 
 [lib]
 proc-macro = true

--- a/src/proc_macros/mod.rs
+++ b/src/proc_macros/mod.rs
@@ -1,164 +1,35 @@
-use {
-    proc_macro::TokenStream,
-    quote::quote,
-    syn::{
-        parse::{Parse, ParseStream, Result},
-        parse_macro_input,
-        Ident, LitChar, Token,
-    },
-};
+use proc_macro::{Literal, TokenStream, TokenTree};
 
-struct KeyEventDef {
-    pub ctrl: bool,
-    pub alt: bool,
-    pub shift: bool,
-    pub code: String,
-}
-
-impl Parse for KeyEventDef {
-    fn parse(input: ParseStream<'_>) -> Result<Self> {
-        let mut code: Option<String> = None;
-        let mut ctrl = false;
-        let mut alt = false;
-        let mut shift = false;
-        fn set<S:Into<String>>(code: &mut Option<String>, c: S) {
-            if let Some(old_code) = &code {
-                // if that wasn't the last one, then it was a modifier
-                panic!("Unrecognized key modifier: {:?}", old_code);
-            }
-            *code = Some(c.into());
-        }
-        loop {
-            if let Ok(c) = input.parse::<LitChar>() {
-                set(&mut code, c.value());
-                break;
-            }
-            // // unclear why a single digit isn't recognized here
-            // if let Ok(d) = input.parse::<syn::LitInt>() {
-            //     let d = d.base10_digits();
-            //     if d.len() > 1 {
-            //         panic!("Not a valid key: {:?}", d);
-            //     }
-            //     set(&mut code, d);
-            //     break;
-            // }
-            if let Ok(ident) = input.parse::<Ident>() {
-                let ident = ident.to_string().to_lowercase();
-                match ident.as_ref() {
-                    "ctrl" => { ctrl = true; }
-                    "alt" => { alt = true; }
-                    "shift" => { shift = true; }
-                    _ => {
-                        set(&mut code, ident);
-                    }
-                }
-                let _ = input.parse::<Token! [-]>(); // separator ignored
-            } else {
-                break;
-            }
-        }
-        Ok(KeyEventDef {
-            ctrl,
-            alt,
-            shift,
-            code: code.expect("key code must be provided"),
-        })
-    }
-}
-
-/// check and expand at compile-time the provided expression
-/// into a valid KeyEvent.
+// Unstable private API for use by `crokey::key_code!` only.
+#[doc(hidden)]
+/// Converts an identifier or punctuation token to its equivalent `char`.
 ///
-///
-/// For example:
-/// ```
-/// # use crokey_proc_macros::key;
-/// let key_event = key!(ctrl-c);
-/// ```
-/// is expanded into:
-///
-/// ```
-/// let key_event = crossterm::event::KeyEvent {
-///     modifiers: crossterm::event::KeyModifiers::CONTROL,
-///     code: crossterm::event::KeyCode::Char('\u{63}'),
-/// };
-/// ```
-///
-/// Keys which can't be valid identifiers in Rust must be put between simple quotes:
-/// ```
-/// # use crokey_proc_macros::key;
-/// let ke = key!(shift-'?');
-/// let ke = key!('5');
-/// let ke = key!(alt-']');
-/// ```
+/// This is the only part of `key_code!` that cannot be performed by a declarative macro alone.
+/// It can also be done by `const`-evaluation but that doesn't work in pattern context.
 #[proc_macro]
-pub fn key(input: TokenStream) -> TokenStream {
-    let key_def = parse_macro_input!(input as KeyEventDef);
-    let modifiers = match (key_def.ctrl, key_def.alt, key_def.shift) {
-        (false, false, false) => quote! { crossterm::event::KeyModifiers::NONE },
-        (true, false, false) => quote! { crossterm::event::KeyModifiers::CONTROL },
-        (true, true, false) => quote! {
-            crossterm::event::KeyModifiers::CONTROL | crossterm::event::KeyModifiers::ALT
-        },
-        (true, false, true) => quote! {
-            crossterm::event::KeyModifiers::CONTROL | crossterm::event::KeyModifiers::SHIFT
-        },
-        (true, true, true) => quote! {
-            crossterm::event::KeyModifiers::CONTROL
-                | crossterm::event::KeyModifiers::ALT
-                | crossterm::event::KeyModifiers::SHIFT
-        },
-        (false, true, false) => quote! { crossterm::event::KeyModifiers::ALT },
-        (false, true, true) => quote! {
-            crossterm::event::KeyModifiers::ALT | crossterm::event::KeyModifiers::SHIFT
-        },
-        (false, false, true) => quote! { crossterm::event::KeyModifiers::SHIFT },
-    };
-    let code = match key_def.code.as_ref() {
-        "backspace" => quote! { crossterm::event::KeyCode::Backspace },
-        "backtab" => quote! { crossterm::event::KeyCode::BackTab },
-        "del" => quote! { crossterm::event::KeyCode::Delete },
-        "delete" => quote! { crossterm::event::KeyCode::Delete },
-        "down" => quote! { crossterm::event::KeyCode::Down },
-        "end" => quote! { crossterm::event::KeyCode::End },
-        "enter" => quote! { crossterm::event::KeyCode::Enter },
-        "esc" => quote! { crossterm::event::KeyCode::Esc },
-        "f1" => quote! { crossterm::event::KeyCode::F(1) },
-        "f2" => quote! { crossterm::event::KeyCode::F(2) },
-        "f3" => quote! { crossterm::event::KeyCode::F(3) },
-        "f4" => quote! { crossterm::event::KeyCode::F(4) },
-        "f5" => quote! { crossterm::event::KeyCode::F(5) },
-        "f6" => quote! { crossterm::event::KeyCode::F(6) },
-        "f7" => quote! { crossterm::event::KeyCode::F(7) },
-        "f8" => quote! { crossterm::event::KeyCode::F(8) },
-        "f9" => quote! { crossterm::event::KeyCode::F(9) },
-        "f10" => quote! { crossterm::event::KeyCode::F(10) },
-        "f11" => quote! { crossterm::event::KeyCode::F(11) },
-        "f12" => quote! { crossterm::event::KeyCode::F(12) },
-        "home" => quote! { crossterm::event::KeyCode::Home },
-        "ins" => quote! { crossterm::event::KeyCode::Insert },
-        "insert" => quote! { crossterm::event::KeyCode::Insert },
-        "left" => quote! { crossterm::event::KeyCode::Left },
-        "pagedown" => quote! { crossterm::event::KeyCode::PageDown },
-        "pageup" => quote! { crossterm::event::KeyCode::PageUp },
-        "right" => quote! { crossterm::event::KeyCode::Right },
-        "space" => quote! { crossterm::event::KeyCode::Char(' ') },
-        "tab" => quote! { crossterm::event::KeyCode::Tab },
-        "up" => quote! { crossterm::event::KeyCode::Up },
-        c if c.len() == 1 => {
-            let c = c.chars().next().unwrap();
-            quote! { crossterm::event::KeyCode::Char(#c) }
-        }
-        _ => {
-            panic!("Unrecognized key code: {:?}", key_def.code);
-        }
-    };
-    quote! {
-        crossterm::event::KeyEvent {
-            modifiers: #modifiers,
-            code: #code,
-        }
-    }.into()
+pub fn to_char(input: TokenStream) -> TokenStream {
+    let c = to_char_inner(input.clone()).unwrap_or_else(|| panic!("unknown key code `{}`", input));
+
+    TokenStream::from(TokenTree::Literal(Literal::character(c)))
 }
 
-
+fn to_char_inner(input: TokenStream) -> Option<char> {
+    let mut input = input.into_iter();
+    let c = match input.next().unwrap() {
+        TokenTree::Ident(ident) => {
+            let ident_string = ident.to_string();
+            let mut chars = ident_string.chars();
+            let c = chars.next().expect("empty identifiers are impossible");
+            if chars.next().is_some() {
+                return None;
+            }
+            c
+        }
+        TokenTree::Punct(punct) => punct.as_char(),
+        _ => return None,
+    };
+    if input.next().is_some() {
+        return None;
+    }
+    Some(c)
+}


### PR DESCRIPTION
By moving all of `key!`'s logic to a declarative macro instead of a procedural one, the dependencies on `proc-macro2`, `syn` and `quote` can be avoided which can improve build times. Unfortunately the entire thing can't be implemented as a declarative macro unless you're willing to sacrifice supporting `key!` in pattern context. There are a couple other miscellaneous changes:

- It now supports bare digits like `key!(5)`.
- It now supports some bare punctuation like `key!(+)`.
- I added another macro `key_code!` used to expand to [`KeyCode`](https://docs.rs/crossterm/latest/crossterm/event/enum.KeyCode.html)s only. This was because it isn't much more code to add, since I'd need all of it anyway.
- Character literals that map directly to other `KeyCode`s (such as `'\n'` to `KeyCode::Enter`) now do so - I think it makes more sense.
- Duplicate modifiers (e.g. `key!(ctrl-ctrl-t)`) are now forbidden, they didn't make much sense anyway.
- Non-ASCII key codes (like `key!(ä)` and `key!('ä')`) are now supported, I just reworked the code to not use `.len() == 1` (which requires that key codes be ASCII).