### PR TITLE
Lighten proc macro dependencies

### DIFF
--- a/src/proc_macros/Cargo.toml
+++ b/src/proc_macros/Cargo.toml
@@ -7,8 +7,7 @@ license = "MIT"
 edition = "2018"
 
 [dependencies]
-crossterm = "0.22.1"
-syn = { version = "1.0", features = ["full"] }
+syn = { version = "1.0", default-features = false, features = ["parsing", "proc-macro"] }
 proc-macro2 = "1.0"
 quote = "1.0"
 


### PR DESCRIPTION
If I can't remove them all, I can at least help to lighten them. The Crossterm dependency isn't necessary since the macro itself doesn't do any terminal work (only the code it generates does). And the `syn` dependency only needs `parsing` for the parsing infrastructure and `proc-macro` for `parse_macro_input!`.