### PR TITLE
Add proc macro crate to a workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,6 @@ rust-version = "1.56"
 [dependencies]
 crossterm = "0.22.1"
 crokey-proc_macros = { path = "src/proc_macros", version = "0.2.0" }
+
+[workspace]
+members = ["src/proc_macros"]


### PR DESCRIPTION
Putting the two crates in the same workspace allows them to share dependency resolution and `target` directories. It makes sense since they're both conceptually part of the same package.