### PR TITLE
Make macros fully hygienic

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,10 +87,49 @@ pub const fn as_letter(key: KeyEvent) -> Option<char> {
     }
 }
 
+/// check and expand at compile-time the provided expression
+/// into a valid KeyEvent.
+///
+///
+/// For example:
+/// ```
+/// # use crokey::key;
+/// let key_event = key!(ctrl-c);
+/// ```
+/// is expanded into:
+///
+/// ```
+/// let key_event = crossterm::event::KeyEvent {
+///     modifiers: crossterm::event::KeyModifiers::CONTROL,
+///     code: crossterm::event::KeyCode::Char('\u{63}'),
+/// };
+/// ```
+///
+/// Keys which can't be valid identifiers in Rust must be put between simple quotes:
+/// ```
+/// # use crokey::key;
+/// let ke = key!(shift-'?');
+/// let ke = key!('5');
+/// let ke = key!(alt-']');
+/// ```
+#[macro_export]
+macro_rules! key {
+    ($($tt:tt)*) => {
+        $crate::__private::key!(($crate) $($tt)*)
+    };
+}
+
+// Not public API. This is internal and to be used only by `key!`.
+#[doc(hidden)]
+pub mod __private {
+    pub use crokey_proc_macros::key;
+    pub use crossterm;
+}
+
 #[cfg(test)]
 mod tests {
     use {
-        crokey_proc_macros::key,
+        crate::key,
         crossterm::event::{KeyCode, KeyEvent, KeyModifiers},
     };
 

--- a/tests/hygiene.rs
+++ b/tests/hygiene.rs
@@ -1,0 +1,9 @@
+#![no_std]
+#![no_implicit_prelude]
+
+#[allow(dead_code)]
+fn hygiene() {
+    ::crokey::key!(M);
+    ::crokey::key!(ctrl-c);
+    ::crokey::key!(alt-shift-ctrl-']');
+}


### PR DESCRIPTION
True hygiene can be achieved by wrapping the procedural macro in a declarative one which delegates to the procedural macro but passes in `$crate`. This way:
- Users can rename their `crossterm` dependency
- Users are allowed to have a module named `crossterm` in scope
- `key!` can be re-exported from anywhere