### PR TITLE
Support const key creation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,17 @@ mod tests {
         crossterm::event::{KeyCode, KeyEvent, KeyModifiers},
     };
 
+    const _: () = {
+        key!(x);
+        key!(ctrl-'{');
+        key!(alt-'{');
+        key!(shift-'{');
+        key!(ctrl-alt-f10);
+        key!(alt-shift-f10);
+        key!(ctrl-shift-f10);
+        key!(ctrl-alt-shift-enter);
+    };
+
     fn no_mod(code: KeyCode) -> KeyEvent {
         KeyEvent::new(code, KeyModifiers::NONE)
     }

--- a/src/proc_macros/mod.rs
+++ b/src/proc_macros/mod.rs
@@ -98,19 +98,19 @@ pub fn key(input: TokenStream) -> TokenStream {
         (false, false, false) => quote! { crossterm::event::KeyModifiers::NONE },
         (true, false, false) => quote! { crossterm::event::KeyModifiers::CONTROL },
         (true, true, false) => quote! {
-            crossterm::event::KeyModifiers::CONTROL | crossterm::event::KeyModifiers::ALT
+            crossterm::event::KeyModifiers::CONTROL.union(crossterm::event::KeyModifiers::ALT)
         },
         (true, false, true) => quote! {
-            crossterm::event::KeyModifiers::CONTROL | crossterm::event::KeyModifiers::SHIFT
+            crossterm::event::KeyModifiers::CONTROL.union(crossterm::event::KeyModifiers::SHIFT)
         },
         (true, true, true) => quote! {
             crossterm::event::KeyModifiers::CONTROL
-                | crossterm::event::KeyModifiers::ALT
-                | crossterm::event::KeyModifiers::SHIFT
+                .union(crossterm::event::KeyModifiers::ALT)
+                .union(crossterm::event::KeyModifiers::SHIFT)
         },
         (false, true, false) => quote! { crossterm::event::KeyModifiers::ALT },
         (false, true, true) => quote! {
-            crossterm::event::KeyModifiers::ALT | crossterm::event::KeyModifiers::SHIFT
+            crossterm::event::KeyModifiers::ALT.union(crossterm::event::KeyModifiers::SHIFT)
         },
         (false, false, true) => quote! { crossterm::event::KeyModifiers::SHIFT },
     };


### PR DESCRIPTION
By using `union` instead of the `|` operator keys can be created in `const` contexts. This also prevents a bug in which `key!(shift-alt-c)` would, in pattern context, match against `key!(alt-c)` and `key!(shift-c)` because `|` would be treated as an alternation operator. Now attempting to use `key!(shift-alt-c)` in pattern context just fails, since I'm not sure there's much else we can do.