### PR TITLE
make the formatted space key readable

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -45,6 +45,7 @@ use {
 ///     ),
 ///     "alt-F6",
 /// );
+///
 /// ```
 #[derive(Debug, Clone)]
 pub struct KeyEventFormat {
@@ -130,6 +131,9 @@ impl<'s> fmt::Display for FormattedKeyEvent<'s> {
             write!(f, "{}", format.shift)?;
         }
         match key.code {
+            Char(' ') => {
+                write!(f, "Space")?;
+            }
             Char('\r') | Char('\n') | Enter => {
                 write!(f, "{}", format.enter)?;
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,5 +122,15 @@ mod tests {
             KeyEvent::new(KeyCode::Char('c'), KeyModifiers::ALT | KeyModifiers::SHIFT)
         );
         assert_eq!(key!(shift - alt - '2'), key!(ALT - SHIFT - 2));
+        assert_eq!(key!(space), key!(' '));
+    }
+
+    #[test]
+    fn format() {
+        let format = crate::KeyEventFormat::default();
+        assert_eq!(format.to_string(key!(insert)), "Insert");
+        assert_eq!(format.to_string(key!(space)), "Space");
+        assert_eq!(format.to_string(key!(alt-Space)), "Alt-Space");
+        assert_eq!(format.to_string(key!(shift-' ')), "Shift-Space");
     }
 }


### PR DESCRIPTION
Space was impossible to read. In the future it may become configurable, just like the Enter key, but I'll wait for somebody to have the need before I make KeyEventFormat heavier.