### PR TITLE
Give a better error on invalid key codes

### DIFF
--- a/src/proc_macros/mod.rs
+++ b/src/proc_macros/mod.rs
@@ -100,10 +100,21 @@ impl Parse for KeyEventDef {
                 quote! { Char(#c) }
             }
             _ => {
-                return Err(Error::new(
-                    code_span,
-                    format_args!("unrecognized key code {:?}", code),
-                ))
+                if input.peek(Token![-]) {
+                    // The code was likely meant to be a modifier
+                    return Err(Error::new(
+                        code_span,
+                        format_args!(
+                            "invalid modifier {:?}; expected `ctrl`, `alt` or `shift`",
+                            code
+                        ),
+                    ));
+                } else {
+                    return Err(Error::new(
+                        code_span,
+                        format_args!("unrecognized key code {:?}", code),
+                    ));
+                }
             }
         };
 


### PR DESCRIPTION
By returning an error during parsing instead of panicking, the error will point to the correct location and display a better message.

Before:

```
error: proc macro panicked
   --> src/lib.rs:120:9
    |
72  |     key!(ctrl-invalid);
    |     ------------------ in this macro invocation
...
120 |         $crate::__private::key!(($crate) $($tt)*)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: message: Unrecognized key code: "invalid"
    = note: this error originates in the macro `key` (in Nightly builds, run with -Z macro-backtrace for more info)
```

After:

```
error: unrecognized key code "invalid"
  --> src/lib.rs:72:15
   |
72 |     key!(ctrl-invalid);
   |               ^^^^^^^
```