### PR TITLE
Add support for parsing hyphen/minus/dash

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,6 +249,7 @@ mod tests {
         assert_eq!(format.to_string(key!(space)), "Space");
         assert_eq!(format.to_string(key!(alt-Space)), "Alt-Space");
         assert_eq!(format.to_string(key!(shift-' ')), "Shift-Space");
+        assert_eq!(format.to_string(key!(alt-hyphen)), "Alt--");
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,6 +238,8 @@ mod tests {
         );
         assert_eq!(key!(shift - alt - '2'), key!(ALT - SHIFT - 2));
         assert_eq!(key!(space), key!(' '));
+        assert_eq!(key!(hyphen), key!('-'));
+        assert_eq!(key!(minus), key!('-'));
     }
 
     #[test]

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -67,6 +67,8 @@ pub fn parse(raw: &str) -> Result<KeyEvent, ParseKeyError> {
         "f11" => F(11),
         "f12" => F(12),
         "space" => Char(' '),
+        "hyphen" => Char('-'),
+        "minus" => Char('-'),
         "tab" => Tab,
         c if c.len() == 1 => Char(c.chars().next().unwrap()),
         _ => {

--- a/src/proc_macros/mod.rs
+++ b/src/proc_macros/mod.rs
@@ -93,6 +93,8 @@ impl Parse for KeyEventDef {
             "pageup" => quote! { PageUp },
             "right" => quote! { Right },
             "space" => quote! { Char(' ') },
+            "hyphen" => quote! { Char('-') },
+            "minus" => quote! { Char('-') },
             "tab" => quote! { Tab },
             "up" => quote! { Up },
             c if c.chars().count() == 1 => {


### PR DESCRIPTION
With this PR, `parse("hyphen")`, `parse("minus")`, `key!(hyphen)`, and `key!(minus)` map to `Char('-')`. I added both "hyphen" and "minus", because unicode calls `-` "hyphen-minus". This fixes #13.

A couple of questions:
1. Should we also add "dash" as an alternative?
2. The formatted version is now like `Alt--`, do you think this is good? AFAIU, the formatted version is not supposed to be round-trip serializable, but you could say that this is ugly. Should it instead be e.g. `Alt-Hyphen`?
3. We should document the special cases like `"space" => Char(' ')` and `"hyphen" => Char('-')` somewhere. The documentation for the `key` macro has something in this direction, but maybe it should be noted in the docs for `parse` as well. To not have it in two places, I propose a section called "special keys" under the main module documentation, and maybe a link to that section in the `key` macro doc. I can add that to this patch if you think this is a good idea. Although the code is so simple that maybe it's acceptable to just let users read the source.