### PR TITLE
Update crossterm to 0.27.0 and bump minor version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crokey"
-version = "0.5.1"
+version = "0.6.0"
 authors = ["dystroy <denys.seguret@gmail.com>"]
 edition = "2021"
 keywords = ["key", "parse"]
@@ -15,7 +15,7 @@ rust-version = "1.56"
 default = ["serde"]
 
 [dependencies]
-crossterm = "0.24.0"
+crossterm = "0.27.0"
 crokey-proc_macros = { path = "src/proc_macros", version = "0.5.1" }
 once_cell = "1.12"
 serde = { optional = true, version = "1.0.130", features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,6 +136,7 @@ pub const fn as_letter(key: KeyEvent) -> Option<char> {
         KeyEvent {
             code: KeyCode::Char(l),
             modifiers: KeyModifiers::NONE,
+            ..
         } => Some(l),
         _ => None,
     }
@@ -156,6 +157,8 @@ pub const fn as_letter(key: KeyEvent) -> Option<char> {
 /// let key_event = crossterm::event::KeyEvent {
 ///     modifiers: crossterm::event::KeyModifiers::CONTROL,
 ///     code: crossterm::event::KeyCode::Char('c'),
+///     kind: crossterm::event::KeyEventKind::Press,
+///     state: crossterm::event::KeyEventState::empty(),
 /// };
 /// ```
 ///

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -100,7 +100,7 @@ pub fn parse(raw: &str) -> Result<KeyEvent, ParseKeyError> {
             return Err(ParseKeyError::new(raw));
         }
     };
-    Ok(KeyEvent { code, modifiers })
+    Ok(KeyEvent::new(code, modifiers))
 }
 
 #[test]

--- a/src/proc_macros/mod.rs
+++ b/src/proc_macros/mod.rs
@@ -158,6 +158,8 @@ pub fn key(input: TokenStream1) -> TokenStream1 {
         #crate_path::__private::crossterm::event::KeyEvent {
             modifiers: #crate_path::__private::#modifier_constant,
             code: #crate_path::__private::crossterm::event::KeyCode::#code,
+            kind: #crate_path::__private::crossterm::event::KeyEventKind::Press,
+            state: #crate_path::__private::crossterm::event::KeyEventState::NONE,
         }
     }
     .into()

--- a/tests/ui/unexpected-eof.stderr
+++ b/tests/ui/unexpected-eof.stderr
@@ -4,7 +4,7 @@ error: unexpected end of input, expected one of: character literal, integer lite
 2 |     crokey::key!();
   |     ^^^^^^^^^^^^^^
   |
-  = note: this error originates in the macro `$crate::__private::key` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `$crate::__private::key` which comes from the expansion of the macro `crokey::key` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected `-`
  --> tests/ui/unexpected-eof.rs:3:5
@@ -12,7 +12,7 @@ error: expected `-`
 3 |     crokey::key!(ctrl);
   |     ^^^^^^^^^^^^^^^^^^
   |
-  = note: this error originates in the macro `$crate::__private::key` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `$crate::__private::key` which comes from the expansion of the macro `crokey::key` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: unexpected end of input, expected one of: character literal, integer literal, identifier
  --> tests/ui/unexpected-eof.rs:4:5
@@ -20,4 +20,4 @@ error: unexpected end of input, expected one of: character literal, integer lite
 4 |     crokey::key!(ctrl-);
   |     ^^^^^^^^^^^^^^^^^^^
   |
-  = note: this error originates in the macro `$crate::__private::key` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `$crate::__private::key` which comes from the expansion of the macro `crokey::key` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
Hello! I am currently developing a CLI app in my spare time using `termimad`. Long story short, I needed to update to the very latest version of `crossterm` so that I can [suppress color output](https://docs.rs/crossterm/latest/crossterm/style/fn.force_color_output.html) based on a command line argument. There were some breaking changes to the public interface in the latest version of `crossterm` (`0.27.0`), so I had to make edits to all of the following libraries locally in order to get everything to work:

## `termimad`
_Please see [this MR](https://github.com/Canop/termimad/pull/57)_
- Bumped `crossterm` version to `0.27.0` from `=0.23.2`
- Some places where `KeyEvent` was being initialized needed to be updated to initialize new members `kind` and `state`
- Added `underline_color` to `CompoundStyle`
- Increased crate `version` to `0.27.0` from `0.26.1`

## `crokey`
- Bumped `crossterm` version to `0.27.0` from `0.24.0`
- Needed to make similar edits to a couple functions and the `key!` macro to initialize new `KeyEvent` members
- Increased crate `version` to `0.6.0` from `0.5.1`

## `coolor`
_Please see [this MR](https://github.com/Canop/coolor/pull/4)_
- Bumped `crossterm` version to `>=0.23.2` from `=0.23.2` to resolve a compile error caused by mismatched `crossterm` versions
- Increased crate `version` to `0.8.1` from `0.8.0`, since (AFAIK) this shouldn't be a breaking change

I ran tests and examples to ensure that everything was working as best I could. However, I would appreciate if you would give the changes a once-over and just verify that I haven't missed any broken behavior. Please note that I am developing on Windows and that I have very limited ability to test cross-platform. If you have a standard way of verifying these changes on Mac and Linux, please let me know if there is a way that I can help. Thank you!