### PR TITLE
crokey-proc_macros: update syn to version 2

### DIFF
--- a/src/proc_macros/Cargo.toml
+++ b/src/proc_macros/Cargo.toml
@@ -11,7 +11,7 @@ crossterm = "0.28"
 proc-macro2 = "1.0"
 quote = "1.0"
 strict = "0.2"
-syn = { version = "1.0", default-features = false, features = ["parsing", "proc-macro"] }
+syn = { version = "2.0", default-features = false, features = ["parsing", "proc-macro"] }
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
not much to do as this crate's proc macro is relatively simple. you can find the full list of breaking changes for syn version 2 [here](https://github.com/dtolnay/syn/releases/tag/2.0.0).

this *would* raise the msrv to rust 1.61, but your msrv is already 1.70 due to crossterm transitively pulling in mio, which has an [msrv of 1.70](https://github.com/tokio-rs/mio/blob/474cd245de98440d17283d3f22964cab734ffc66/Cargo.toml#L3)